### PR TITLE
fix a deadlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# 使用 Python 3.11 的官方镜像作为基础镜像
-FROM python:3.11.7-alpine
+# 使用 Python 3.12 的官方镜像作为基础镜像
+FROM python:3.12-alpine
 
 # 设置工作目录为 /src
 WORKDIR /src
@@ -11,4 +11,4 @@ COPY src /src
 RUN pip install --no-cache-dir -r requirements.txt
 
 # 启动程序
-cmd ["python", "cloudreve_pay.py"]
+CMD ["python", "-u", "cloudreve_pay.py"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cloudreve自定义付款渠道-爱发电接口
 
 参考 https://docsv4.cloudreve.org/zh/payment/custom 构建
 
-推荐使用 **Python3.11**
+推荐使用 **Python3.12**
 
 ## 使用方法
 
@@ -61,6 +61,7 @@ services:
     command: ["python","-u", "cloudreve_pay.py"]
     environment:
       - SITE_URL=https://demo.cloudreve.org
+      - COMMUNICATION_KEY=xxxxxx
       - USER_ID=abcxxxxxxx123
       - TOKEN=aAABBB123xxxxzzz
       - PORT=5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: [ "python","-u", "cloudreve_pay.py" ]
     environment:
       - SITE_URL=https://pro.abc.com网盘的域名,最后没有/
+      - COMMUNICATION_KEY=Cloudreve通信密钥
       - USER_ID=爱发电的userid
       - TOKEN=爱发电的token
       - PORT=绑定端口,这里用48516

--- a/src/afdian.py
+++ b/src/afdian.py
@@ -12,30 +12,47 @@ except:
     print("未找到dotenv模块")
     exit()
 
-
 def db_file():
-    # 判断afdian_pay.db是否存在
-    if os.path.exists("afdian_pay.db"):
-        return
-    else:
-        # 创建数据库
-        conn = sqlite3.connect('afdian_pay.db')
-        c = conn.cursor()
-        # 创建表
-        c.execute('''CREATE TABLE afdian_pay
-               (order_no text, amount text, notify_url text, is_paid BOOLEAN DEFAULT 0)''')
-        conn.commit()
-        conn.close()
-        return
+    conn = sqlite3.connect('afdian_pay.db')
+    c = conn.cursor()
+    # 创建表
+    c.execute('''CREATE TABLE IF NOT EXISTS afdian_pay
+           (order_no TEXT PRIMARY KEY,
+            amount TEXT,
+            notify_url TEXT,
+            is_paid BOOLEAN DEFAULT 0,
+            notify_status INTEGER DEFAULT 0,
+            notify_attempts INTEGER DEFAULT 0,
+            notify_next_at INTEGER DEFAULT 0,
+            notify_last_at INTEGER DEFAULT 0,
+            notify_last_error TEXT DEFAULT ''
+           )''')
+    conn.commit()
+
+    # WAL
+    try:
+        conn.execute("PRAGMA journal_mode=WAL;")
+    except Exception:
+        print("[WARN] Failed to enable WAL")
+        pass
+
+    conn.commit()
+    conn.close()
+    return
 
 
 def db_insert(order_no, amount, notify_url):
     db_file()
+    now = int(time.time())
     conn = sqlite3.connect('afdian_pay.db')
     c = conn.cursor()
     # 插入数据
-    c.execute("INSERT INTO afdian_pay (order_no, amount, notify_url, is_paid) VALUES (?, ?, ?, 0)",
-              (order_no, amount, notify_url))
+    c.execute("""
+            INSERT OR REPLACE INTO afdian_pay
+            (order_no, amount, notify_url, is_paid, notify_status, notify_attempts, notify_next_at, notify_last_at, notify_last_error)
+            VALUES (?, ?, ?, 0, 0, 0, ?, 0, '')
+        """, (order_no, amount, notify_url, now))
+
     conn.commit()
     conn.close()
     return True
@@ -65,23 +82,108 @@ def check_order(order_no, out_trade_no):
     conn = sqlite3.connect('afdian_pay.db')
     c = conn.cursor()
     # 查询数据
-    cursor = c.execute("SELECT order_no, amount, notify_url from afdian_pay")
-    for row in cursor:
-        if row[0] == order_no:
-            conn.close()
-            return row
+    c.execute("SELECT order_no, amount, notify_url FROM afdian_pay WHERE order_no = ? LIMIT 1", (order_no,))
+    row = c.fetchone()
     conn.close()
-    return ["", 0, ""]
+    if not row:
+        return ["", 0, ""]
+    return row
 
 
-def mark_order_paid(order_no):
+def mark_order_paid_and_enqueue_notify(order_no):
     db_file()
+    now = int(time.time())
     conn = sqlite3.connect('afdian_pay.db')
     c = conn.cursor()
-    c.execute("UPDATE afdian_pay SET is_paid = 1 WHERE order_no = ?", (order_no,))
+    c.execute("""
+        UPDATE afdian_pay
+        SET is_paid = 1,
+            notify_status = 0,
+            notify_next_at = ?,
+            notify_last_error = ''
+        WHERE order_no = ?
+    """, (now, order_no))
     conn.commit()
     conn.close()
     return True
+
+def _notify_backoff_seconds(attempts: int) -> int:
+    """
+    attempts 从 1 开始计数。
+    5s, 10s, 20s, 40s... 最长 30min
+    """
+    base = 5
+    sec = base * (2 ** (attempts - 1))
+    return min(sec, 1800)
+
+def fetch_due_notify_jobs(now: int):
+    db_file()
+    conn = sqlite3.connect('afdian_pay.db')
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute("""
+        SELECT order_no, notify_url, notify_attempts
+        FROM afdian_pay
+        WHERE is_paid = 1
+          AND notify_url != ''
+          AND notify_status != 1
+          AND notify_status != 3
+          AND notify_next_at <= ?
+        ORDER BY notify_next_at ASC
+        LIMIT ?
+    """, (now, 10)) #最多批量回调10项
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+def mark_notify_success(order_no: str):
+    now = int(time.time())
+    conn = sqlite3.connect('afdian_pay.db')
+    c = conn.cursor()
+    c.execute("""
+        UPDATE afdian_pay
+        SET notify_status = 1,
+            notify_last_at = ?,
+            notify_last_error = ''
+        WHERE order_no = ?
+    """, (now, order_no))
+    conn.commit()
+    conn.close()
+
+def mark_notify_failure(order_no: str, attempts_after: int, err: str):
+    now = int(time.time())
+    next_at = now + _notify_backoff_seconds(attempts_after)
+    status = 2
+    if attempts_after >= 20:
+        status = 3  # giving up
+    conn = sqlite3.connect('afdian_pay.db')
+    c = conn.cursor()
+    c.execute("""
+        UPDATE afdian_pay
+        SET notify_status = ?,
+            notify_attempts = ?,
+            notify_last_at = ?,
+            notify_next_at = ?,
+            notify_last_error = ?
+        WHERE order_no = ?
+    """, (status, attempts_after, now, next_at, err[:500], order_no))
+    conn.commit()
+    conn.close()
+
+def try_notify_once(url: str) -> tuple[bool, str]:
+    try:
+        resp = requests.get(url, timeout=(3, 5))
+        if resp.status_code != 200:
+            return False, f"HTTP {resp.status_code}"
+        try:
+            j = resp.json()
+        except Exception:
+            return False, "Invalid JSON"
+        if j.get("code") == 0:
+            return True, ""
+        return False, f"code={j.get('code')}, body={resp.text[:200]}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
 
 
 def get_order_status(order_no):

--- a/src/cloudreve_pay.py
+++ b/src/cloudreve_pay.py
@@ -38,27 +38,15 @@ app = Flask(__name__)
 # 初始化检查
 def check():
     # 判断.env文件是否存在
-    if os.path.exists('.env'):
-        if os.environ.get('SITE_URL') == "":
-            print("SITE_URL未设置,已停止运行")
-            exit()
-        if os.environ.get('COMMUNICATION_KEY') == "":
-            print("COMMUNICATION_KEY未设置,已停止运行")
-            exit()
-        if os.environ.get('USER_ID') == "":
-            print("USER_ID未设置,已停止运行")
-            exit()
-        if os.environ.get('TOKEN') == "":
-            print("TOKEN未设置,已停止运行")
-            exit()
-        if os.environ.get('PORT') == "":
-            print("PORT未设置,已停止运行")
-            exit()
-        print("初始化检查通过")
-        return
-    else:
+    if not os.path.exists('.env'):
         print("未找到.env文件,已停止运行")
         exit()
+    load_dotenv('.env')
+    for key in ('SITE_URL', 'COMMUNICATION_KEY', 'USER_ID', 'TOKEN', 'PORT'):
+        if not os.environ.get(key):
+            print(f"{key}未设置,已停止运行")
+            exit()
+    print("初始化检查通过")
 
 @app.route('/afdian', methods=['POST'])
 def respond():
@@ -231,13 +219,12 @@ def check_order():
         back = json.dumps(back, ensure_ascii=False)
         return Response(back, mimetype='application/json')
 
-# 初始化检查
+# 初始化检查、载入配置
 check()
 # 设置货币最小单位
 CURRENCY_UNIT = {'USD': 100, 'EUR': 100, 'GBP': 100, 'JPY': 1, 'CNY': 100, 'HKD': 100, 'SGD': 100, 'KRW': 1, 'INR': 100, 'RUB': 100, 'BRL': 100, 'AUD': 100, 'CAD': 100, 'CHF': 100}
 print("Cloudreve Afdian Pay Server\t已启动\nGithub: https://github.com/essesoul/Cloudreve-AfdianPay")
 print("-------------------------")
-load_dotenv('.env')
 port = str(os.getenv('PORT'))
 print("程序运行端口：" + port)
 server = pywsgi.WSGIServer(('0.0.0.0', int(port)), app)

--- a/src/cloudreve_pay.py
+++ b/src/cloudreve_pay.py
@@ -37,10 +37,7 @@ app = Flask(__name__)
 
 # 初始化检查
 def check():
-    # 判断.env文件是否存在
-    if not os.path.exists('.env'):
-        print("未找到.env文件,已停止运行")
-        exit()
+    # .env文件可选，有则加载（不覆盖已有环境变量）
     load_dotenv('.env')
     for key in ('SITE_URL', 'COMMUNICATION_KEY', 'USER_ID', 'TOKEN', 'PORT'):
         if not os.environ.get(key):

--- a/src/cloudreve_pay.py
+++ b/src/cloudreve_pay.py
@@ -23,6 +23,7 @@ except:
     print("未找到CurrencyConverter模块")
     exit()
 try:
+    import gevent
     from gevent import pywsgi
 except:
     print("未找到gevent模块")
@@ -34,6 +35,33 @@ except:
     exit()
 app = Flask(__name__)
 
+def notify_worker_loop():
+    print("[INFO] notify worker started")
+    while True:
+        try:
+            now = int(time.time())
+            jobs = afdian.fetch_due_notify_jobs(now)
+            if not jobs:
+                gevent.sleep(1.0)
+                continue
+
+            for job in jobs:
+                order_no = job["order_no"]
+                url = job["notify_url"]
+                attempts = int(job["notify_attempts"] or 0)
+                ok, err = afdian.try_notify_once(url)
+                if ok:
+                    print(f"[INFO] notify success order_no={order_no}")
+                    afdian.mark_notify_success(order_no)
+                else:
+                    attempts_after = attempts + 1
+                    print(f"[WARN] notify failed order_no={order_no} attempts={attempts_after} err={err}")
+                    afdian.mark_notify_failure(order_no, attempts_after, err)
+            # 防止一轮处理过久饿死其他 greenlet
+            gevent.sleep(0)
+        except Exception as e:
+            print(f"[ERROR] notify worker exception: {type(e).__name__}: {e}")
+            gevent.sleep(2.0)
 
 # 初始化检查
 def check():
@@ -62,21 +90,9 @@ def respond():
         amount = raw[1]
     if afd_amount == amount:
         # 订单金额相同
-        # 标记订单为已支付
-        afdian.mark_order_paid(order_no)
-        # 通知网站
-        notify_url = raw[2]
-        url = notify_url
-        # 发送get请求
-        for attempt in range(3):
-            try:
-                resp = requests.get(url)
-                if resp.status_code == 200 and resp.json().get('code') == 0:
-                    break
-            except Exception:
-                if attempt == 2:  # 最后一次重试仍然失败
-                    raise
-                time.sleep(2 ** attempt)
+        # 标记订单为已支付、可回调
+        afdian.mark_order_paid_and_enqueue_notify(order_no)
+
     # json格式化
     back = '{"ec":200,"em":""}'
     json.dumps(back, ensure_ascii=False)
@@ -220,6 +236,8 @@ def check_order():
 check()
 # 设置货币最小单位
 CURRENCY_UNIT = {'USD': 100, 'EUR': 100, 'GBP': 100, 'JPY': 1, 'CNY': 100, 'HKD': 100, 'SGD': 100, 'KRW': 1, 'INR': 100, 'RUB': 100, 'BRL': 100, 'AUD': 100, 'CAD': 100, 'CHF': 100}
+# 启动后台回调worker
+gevent.spawn(notify_worker_loop)
 print("Cloudreve Afdian Pay Server\t已启动\nGithub: https://github.com/essesoul/Cloudreve-AfdianPay")
 print("-------------------------")
 port = str(os.getenv('PORT'))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
-currencyconverter==0.18.5
-Flask==3.1.1
-gevent==24.11.1
-python-dotenv==1.1.0
-Requests==2.32.4
+currencyconverter==0.18.15
+Flask==3.1.3
+gevent==25.9.1
+python-dotenv==1.2.1
+requests==2.32.5


### PR DESCRIPTION
之前测试不周到，发现在支付成功后向Cloudreve发送回调（[文档](https://docs.cloudreve.org/zh/payment/custom#%E5%8F%91%E9%80%81%E5%9B%9E%E8%B0%83)）时会出现死锁，导致充值无法到账、程序卡死。  
已将其修复，另更新了下依赖版本。  
因为没做迁移，使用此版本需要先删除已有数据库.db文件。